### PR TITLE
feat: Alternative syntax respecting open-closed principle

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,6 @@ If bundler is not being used to manage dependencies, install the gem by executin
 ## Usage
 
 ```ruby
-ActiveRecord::Schema.define do
-  create_table :orders do |t|
-    t.integer :state, limit: 1, default: 0
-  end
-end
-
 class Order < ActiveRecord::Base
   include Discriminable
 
@@ -43,6 +37,28 @@ class Order < ActiveRecord::Base
 end
 
 class Cart < Order
+end
+
+Cart.create
+=> #<Cart id: 1, state: "open">
+Order.all
+=> #<ActiveRecord::Relation [#<Cart id: 1, state: "open">]>
+```
+
+### Alternative syntax
+
+Instead of defining subclass names within the parent you may prefer to be open for extension but closed for modification (open-closed principle) using the alternative syntax.
+
+```ruby
+class Order < ActiveRecord::Base
+  include Discriminable
+
+  enum state: { open: 0, completed: 1 }
+  discriminable_by :state
+end
+
+class Cart < Order
+  discriminable_as :open
 end
 
 Cart.create

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 - [x] multiple values per subclass
 - [x] default to first value when using hash syntax
-- [ ] open-closed principle
+- [x] open-closed principle
 - [ ] use `type` column with enum, int, string, etc.
 - [ ] test permitted attributes
 - [ ] `self.abstract_class = true`

--- a/test/test_open_closed_principle.rb
+++ b/test/test_open_closed_principle.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "helper"
+
+class TestOpenClosedPrinciple < Case
+  class Property < ActiveRecord::Base
+    include Discriminable
+
+    enum kind: { number: 0, single_option: 1, multi_option: 2, range: 3 }
+    discriminable_by :kind
+  end
+
+  class NumberProperty < Property
+    discriminable_as :number
+  end
+
+  class OptionProperty < Property
+    discriminable_as :single_option, :multi_option
+  end
+
+  class RangeProperty < Property
+    discriminable_as :range
+  end
+
+  def setup
+    ActiveRecord::Schema.define do
+      create_table :properties do |t|
+        t.integer :kind, limit: 1, default: 0
+      end
+    end
+  end
+
+  def test_sti_name_default
+    assert_equal NumberProperty.sti_name, "number"
+    assert_equal OptionProperty.sti_name, "single_option"
+    assert_equal RangeProperty.sti_name, "range"
+  end
+
+  def test_creation
+    assert_predicate NumberProperty.create, :number?
+    assert_predicate OptionProperty.create, :single_option?
+    assert_predicate RangeProperty.create, :range?
+  end
+
+  def test_building
+    assert_instance_of NumberProperty, Property.number.build
+    assert_instance_of OptionProperty, Property.multi_option.build
+    assert_instance_of RangeProperty, Property.range.build
+  end
+end


### PR DESCRIPTION
New class methods `discriminable_by` and `discriminable_as` added:

```ruby
class Order < ActiveRecord::Base
  include Discriminable

  discriminable_by :state
end

class Cart < Order
  discriminable_as :open
end
```

Thanks @koffeinfrei for the naming suggestion.
Note that the naming of the additional class methods should be Rails-like. Compare them with `respond_to` and `respond_with`.
