### PR TITLE
Fix querying with multiple discriminable values

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 - [x] multiple values per subclass
 - [x] default to first value when using hash syntax
 - [x] open-closed principle
-- [ ] Bug: multiple values: Child.all query (double-check)
+- [x] Bug: multiple values: Child.all query (double-check)
 - [ ] Rails 5 support (see rails-5 branch)
 - [ ] rubocop-minitest
 - [ ] more tests / examples

--- a/lib/discriminable.rb
+++ b/lib/discriminable.rb
@@ -72,6 +72,17 @@ module Discriminable
       discriminable_inverse_map[name]
     end
 
+    def sti_names
+      ([self] + descendants).flat_map(&:discriminable_values)
+    end
+
+    def type_condition(table = arel_table)
+      return super unless discriminable_values.present?
+
+      sti_column = table[inheritance_column]
+      predicate_builder.build(sti_column, sti_names)
+    end
+
     def sti_class_for(value)
       return self unless (type_name = discriminable_map[value])
 

--- a/test/test_open_closed_principle_aliased_integer.rb
+++ b/test/test_open_closed_principle_aliased_integer.rb
@@ -20,6 +20,10 @@ class TestOpenClosedPrincipleAliasedInteger < Case
     discriminable_as 2, 3
   end
 
+  class CrazyOptionProperty < OptionProperty
+    discriminable_as 4, 5
+  end
+
   def setup
     ActiveRecord::Schema.define do
       create_table :properties do |t|
@@ -36,8 +40,19 @@ class TestOpenClosedPrincipleAliasedInteger < Case
   def test_creation_and_loading
     assert_equal 1, NumberProperty.create.kind
     assert_equal 2, OptionProperty.create.kind
+    assert_equal 3, OptionProperty.create(kind: 3).kind
     assert_instance_of NumberProperty, Property.first
     assert_instance_of OptionProperty, Property.last
+    assert_equal 2, OptionProperty.all.count
+  end
+
+  def test_sti_names
+    assert_equal (2..5).to_a, OptionProperty.sti_names
+  end
+
+  def test_loading_multiple_values
+    assert_match(/^SELECT.*WHERE.*kind_with_some_postfix.*IN.*#{OptionProperty.sti_names.join('.*')}.*$/,
+                 OptionProperty.all.to_sql)
   end
 
   def test_creation_using_parent

--- a/test/test_sti_aliased.rb
+++ b/test/test_sti_aliased.rb
@@ -29,7 +29,6 @@ class TestStiAliased < Case
     Order.create
     Cart.create
     assert_equal 2, Order.count
-
     assert_equal 1, Cart.count
   end
 


### PR DESCRIPTION
When multiple discriminable values are provided, querying wouldn't work.

```ruby
class OptionProperty < Property
  discriminable_as 2, 3
end

# OptionProperty.all.to_sql would not include the `IN (2, 3)` where-condition.
```

This PR fixes it. Including support for an arbitrary number and depth of subclasses.