### PR TITLE
chore: add a spec when value is undiscriminable

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,7 @@
 - [x] Factory Bot: create :property, kind: 3 => should instantiate a child OptionProperty… => Works if constant OptionProperty is loaded
 - [x] use `type` column with enum, int, string, etc.
 - [x] ~~`self.abstract_class = true` ➔ This results in separate tables~~
+- [x] What if value is not a “discriminable” value and class cannot be found?
 - [ ] rubocop-minitest
 - [ ] more tests / examples. [alias, non-alias] ⨉ [integer, string, boolean] ⨉ [enum, non-enum] ⨉ [type-column, non-type-column] ⨉ [multiple-values, single-values] ⨉ [subclasses, subsubclasses] ⨉ [hash-syntax, ocp-syntax]
 - [ ] Documentation

--- a/test/test_open_closed_principle_aliased_integer.rb
+++ b/test/test_open_closed_principle_aliased_integer.rb
@@ -32,6 +32,11 @@ class TestOpenClosedPrincipleAliasedInteger < Case
     end
   end
 
+  def test_undiscriminable_value
+    Property.create kind: 99
+    assert_instance_of Property, Property.first
+  end
+
   def test_sti_name_default
     assert_equal 1, NumberProperty.sti_name
     assert_equal 2, OptionProperty.sti_name


### PR DESCRIPTION
As @franco pointed out, we should add a spec that verifies loading records with “undiscriminable” values.
