### PR TITLE
feat: Alternate syntax using attribute/value instead of prepositions

### DIFF
--- a/lib/discriminable.rb
+++ b/lib/discriminable.rb
@@ -29,8 +29,12 @@ module Discriminable
     class_attribute :_discriminable_values, instance_writer: false
   end
 
-  # Specify the column to use for discrimination.
+  # This adds
+  # - `discriminable_attribute` and
+  # - `discriminalbe_value`
+  # class methods (plus some aliases).
   module ClassMethods
+    # Specify the attribute/column at the root class to use for discrimination.
     def discriminable_by(attribute)
       raise "Subclasses should not override .discriminable_by" unless base_class?
 
@@ -40,8 +44,17 @@ module Discriminable
       attribute = attribute.to_s
       self.inheritance_column = attribute_aliases[attribute] || attribute
     end
-    # alias_method :discriminable_by, :discriminable_attribute, …:column
 
+    # “Aliases” for discriminable_by
+    def discriminable_attribute(attribute)
+      discriminable_by(attribute)
+    end
+
+    def discriminable_on(attribute)
+      discriminable_by(attribute)
+    end
+
+    # Specify the values the subclass corresponds to.
     def discriminable_as(*values)
       raise "Only subclasses should specify .discriminable_as" if base_class?
 
@@ -49,7 +62,14 @@ module Discriminable
         value.instance_of?(Symbol) ? value.to_s : value
       end
     end
-    # alias_method :discriminable_as, :discriminable_value
+
+    def discriminable_value(*values)
+      discriminable_as(*values)
+    end
+
+    def discriminable_values(*values)
+      discriminable_as(*values)
+    end
 
     # This is the value of the discriminable attribute
     def sti_name

--- a/test/test_alternate_syntax.rb
+++ b/test/test_alternate_syntax.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "helper"
+
+class TestAlternateSyntax < Case
+  class Property < ActiveRecord::Base
+    include Discriminable
+
+    enum type: { value: 0, single_option: 1, multi_option: 2, range: 3 }
+    discriminable_attribute :type
+  end
+
+  class ValueProperty < Property
+    discriminable_value :value
+  end
+
+  class OptionProperty < Property
+    discriminable_values :single_option, :multi_option
+  end
+
+  def setup
+    ActiveRecord::Schema.define do
+      create_table :properties do |t|
+        t.integer :type, limit: 1, default: 0
+      end
+    end
+  end
+
+  def test_sti_name_default
+    assert_equal ValueProperty.sti_name, "value"
+    assert_equal OptionProperty.sti_name, "single_option"
+  end
+
+  def test_creation
+    assert_predicate ValueProperty.create, :value?
+    assert_predicate OptionProperty.create, :single_option?
+  end
+
+  def test_building
+    assert_instance_of ValueProperty, Property.value.build
+    assert_instance_of OptionProperty, Property.multi_option.build
+  end
+end


### PR DESCRIPTION
- Aliases `discriminable_attribute` and `discriminable_on` for existing `discriminable_by`.
- Aliases `discriminable_value` and `discriminable_values` for existing `discriminable_as`.
