### PR TITLE
refactor/api and aliases

### DIFF
--- a/lib/discriminable.rb
+++ b/lib/discriminable.rb
@@ -48,15 +48,15 @@ module Discriminable
     alias discriminable_on discriminable_attribute
 
     # Specify the values the subclass corresponds to.
-    def discriminable_as(*values)
-      raise "Only subclasses should specify .discriminable_as" if base_class?
+    def discriminable_value(*values)
+      raise "Only subclasses should specify .discriminable_value" if base_class?
 
       self._discriminable_values = values.map do |value|
         value.instance_of?(Symbol) ? value.to_s : value
       end
     end
-    alias discriminable_value discriminable_as
-    alias discriminable_values discriminable_as
+    alias discriminable_values discriminable_value
+    alias discriminable_as discriminable_value
 
     # This is the value of the discriminable attribute
     def sti_name

--- a/lib/discriminable.rb
+++ b/lib/discriminable.rb
@@ -17,7 +17,7 @@ require "active_support"
 # class Customer < ActiveRecord::Base
 #   include Discriminable
 #
-#   discriminable_by :state
+#   discriminable_attribute :state
 # end
 #
 module Discriminable
@@ -35,8 +35,8 @@ module Discriminable
   # class methods (plus some aliases).
   module ClassMethods
     # Specify the attribute/column at the root class to use for discrimination.
-    def discriminable_by(attribute)
-      raise "Subclasses should not override .discriminable_by" unless base_class?
+    def discriminable_attribute(attribute)
+      raise "Subclasses should not override .discriminable_attribute" unless base_class?
 
       self._discriminable_map ||= _discriminable_map_memoized
       self._discriminable_inverse_map ||= _discriminable_inverse_map_memoized
@@ -44,8 +44,8 @@ module Discriminable
       attribute = attribute.to_s
       self.inheritance_column = attribute_aliases[attribute] || attribute
     end
-    alias discriminable_attribute discriminable_by
-    alias discriminable_on discriminable_by
+    alias discriminable_by discriminable_attribute
+    alias discriminable_on discriminable_attribute
 
     # Specify the values the subclass corresponds to.
     def discriminable_as(*values)

--- a/lib/discriminable.rb
+++ b/lib/discriminable.rb
@@ -44,15 +44,8 @@ module Discriminable
       attribute = attribute.to_s
       self.inheritance_column = attribute_aliases[attribute] || attribute
     end
-
-    # “Aliases” for discriminable_by
-    def discriminable_attribute(attribute)
-      discriminable_by(attribute)
-    end
-
-    def discriminable_on(attribute)
-      discriminable_by(attribute)
-    end
+    alias discriminable_attribute discriminable_by
+    alias discriminable_on discriminable_by
 
     # Specify the values the subclass corresponds to.
     def discriminable_as(*values)
@@ -62,14 +55,8 @@ module Discriminable
         value.instance_of?(Symbol) ? value.to_s : value
       end
     end
-
-    def discriminable_value(*values)
-      discriminable_as(*values)
-    end
-
-    def discriminable_values(*values)
-      discriminable_as(*values)
-    end
+    alias discriminable_value discriminable_as
+    alias discriminable_values discriminable_as
 
     # This is the value of the discriminable attribute
     def sti_name

--- a/test/test_alternate_syntax.rb
+++ b/test/test_alternate_syntax.rb
@@ -7,7 +7,7 @@ class TestAlternateSyntax < Case
     include Discriminable
 
     enum type: { value: 0, single_option: 1, multi_option: 2, range: 3 }
-    discriminable_attribute :type
+    discriminable_by :type
   end
 
   class ValueProperty < Property

--- a/test/test_alternate_syntax.rb
+++ b/test/test_alternate_syntax.rb
@@ -11,11 +11,11 @@ class TestAlternateSyntax < Case
   end
 
   class ValueProperty < Property
-    discriminable_value :value
+    discriminable_as :value
   end
 
   class OptionProperty < Property
-    discriminable_values :single_option, :multi_option
+    discriminable_as :single_option, :multi_option
   end
 
   def setup

--- a/test/test_boolean.rb
+++ b/test/test_boolean.rb
@@ -6,7 +6,7 @@ class TestBoolean < Case
   class Response < ActiveRecord::Base
     include Discriminable
 
-    discriminable_by :affirmative
+    discriminable_attribute :affirmative
   end
 
   class Yes < Response

--- a/test/test_boolean.rb
+++ b/test/test_boolean.rb
@@ -10,7 +10,7 @@ class TestBoolean < Case
   end
 
   class Yes < Response
-    discriminable_as true
+    discriminable_value true
   end
 
   def setup

--- a/test/test_enum.rb
+++ b/test/test_enum.rb
@@ -7,7 +7,7 @@ class TestEnum < Case
     include Discriminable
 
     enum state: { open: 0, completed: 1 }
-    discriminable_by :state
+    discriminable_attribute :state
   end
 
   class Cart < Order

--- a/test/test_enum.rb
+++ b/test/test_enum.rb
@@ -11,7 +11,7 @@ class TestEnum < Case
   end
 
   class Cart < Order
-    discriminable_as :open
+    discriminable_value :open
   end
 
   def setup

--- a/test/test_enum_multiple.rb
+++ b/test/test_enum_multiple.rb
@@ -11,11 +11,11 @@ class TestEnumMultiple < Case
   end
 
   class Cart < Order
-    discriminable_as :open
+    discriminable_value :open
   end
 
   class Invoice < Order
-    discriminable_as :invoiced, :reminded
+    discriminable_value :invoiced, :reminded
   end
 
   def setup

--- a/test/test_enum_multiple.rb
+++ b/test/test_enum_multiple.rb
@@ -7,7 +7,7 @@ class TestEnumMultiple < Case
     include Discriminable
 
     enum state: { open: 0, completed: 1, invoiced: 2, reminded: 3 }
-    discriminable_by :state
+    discriminable_attribute :state
   end
 
   class Cart < Order

--- a/test/test_open_closed_principle.rb
+++ b/test/test_open_closed_principle.rb
@@ -7,7 +7,7 @@ class TestOpenClosedPrinciple < Case
     include Discriminable
 
     enum type: { value: 0, single_option: 1, multi_option: 2, range: 3 }
-    discriminable_by :type
+    discriminable_attribute :type
   end
 
   class ValueProperty < Property

--- a/test/test_open_closed_principle.rb
+++ b/test/test_open_closed_principle.rb
@@ -11,15 +11,15 @@ class TestOpenClosedPrinciple < Case
   end
 
   class ValueProperty < Property
-    discriminable_as :value
+    discriminable_value :value
   end
 
   class OptionProperty < Property
-    discriminable_as :single_option, :multi_option
+    discriminable_value :single_option, :multi_option
   end
 
   class RangeProperty < Property
-    discriminable_as :range
+    discriminable_value :range
   end
 
   def setup

--- a/test/test_open_closed_principle_aliased_integer.rb
+++ b/test/test_open_closed_principle_aliased_integer.rb
@@ -13,15 +13,15 @@ class TestOpenClosedPrincipleAliasedInteger < Case
   end
 
   class NumberProperty < Property
-    discriminable_as 1
+    discriminable_value 1
   end
 
   class OptionProperty < Property
-    discriminable_as 2, 3
+    discriminable_value 2, 3
   end
 
   class CrazyOptionProperty < OptionProperty
-    discriminable_as 4, 5
+    discriminable_value 4, 5
   end
 
   def setup

--- a/test/test_open_closed_principle_aliased_integer.rb
+++ b/test/test_open_closed_principle_aliased_integer.rb
@@ -9,7 +9,7 @@ class TestOpenClosedPrincipleAliasedInteger < Case
     alias_attribute :kind, :kind_with_some_postfix
 
     # No enum this time
-    discriminable_by :kind
+    discriminable_attribute :kind
   end
 
   class NumberProperty < Property


### PR DESCRIPTION
Instead of using prepositions, let’s reuse common naming for a “discriminatoer” that is used in similar ways in Java JPA, etc.

- chore: refactor aliases
- chore: make discriminable_attribute default api
- chore: make discriminable_value default api
